### PR TITLE
rpki-validator.sh: add a run in foreground mode

### DIFF
--- a/rpki-validator-app/README.txt
+++ b/rpki-validator-app/README.txt
@@ -56,10 +56,11 @@ Usage
 -----
 
 = Decompress the downloaded package
-= Run the RPKI Validator script from the root folder to start, stop and check the status 
-  of the application
+= Run the RPKI Validator script from the root folder to start, run (in foreground), stop
+  and check the status of the application
 
        ./rpki-validator.sh start  [-c /path/to/my-configuration.conf]
+   or  ./rpki-validator.sh run    [-c /path/to/my-configuration.conf]
    or  ./rpki-validator.sh stop   [-c /path/to/my-configuration.conf]
    or  ./rpki-validator.sh status [-c /path/to/my-configuration.conf]
    


### PR DESCRIPTION
Running "rpki-validator.sh run" will start the RPKI Validator in the
foreground (i.e. without it forking and detaching from the terminal).
This is the preferred behaviour when run from modern GNU/Linux init
systems such as systemd and upstart, which take care of daemonisation.
