### PR TITLE
Update rpki-validator.sh

### DIFF
--- a/rpki-validator-app/src/main/scripts/rpki-validator.sh
+++ b/rpki-validator-app/src/main/scripts/rpki-validator.sh
@@ -91,6 +91,13 @@ if [[ -n $MODE ]]; then
    exit
 fi
 
+#Validate that rsync is available in the path and is executable
+if ! [ -x "$(command -v rsync)" ]; then
+  echo 'rsync not found. It is necessary to sync repositories.' >&2
+  exit 1
+fi
+
+
 # Determine config file location
 getopts ":c:" OPT_NAME
 CONFIG_FILE=${OPTARG:-conf/rpki-validator.conf}


### PR DESCRIPTION
This small change is capable of checking if rsync is installed and is executable. If rsync is not found aborts scripts execution with a nice message and with exit status 1